### PR TITLE
Better non-existant files handling

### DIFF
--- a/lib/MojoX/Renderer/TT.pm
+++ b/lib/MojoX/Renderer/TT.pm
@@ -79,7 +79,7 @@ sub _render {
     unless ($ok) {
         my $e = $self->tt->error;
 
-        if ($e =~ m/not found/) {
+        if ($e =~ m/not found|no such file or directory/i) {
             $c->app->log->error(qq/Template "$t" missing or not readable./);
             $c->render_not_found;
             return;


### PR DESCRIPTION
TT being set as default renderer ($self->renderer->default_handler('tt')) throws a different error on a missed file (looks like $! after open()): "script/../templates/example/welcome.html.tt: No such file or directory". As a result we get 500 instead of 404. I added that message.
