### PR TITLE
Fixed failing tests

### DIFF
--- a/lib/MojoX/Renderer/TT.pm
+++ b/lib/MojoX/Renderer/TT.pm
@@ -56,7 +56,7 @@ sub _render {
     my ($self, $renderer, $c, $output, $options) = @_;
 
     # Inline
-    my $inline = $c->{stash}->{inline};
+    my $inline = $options->{inline};
 
     # Template
     my $t = $renderer->template_name($options);

--- a/t/lite_app.t
+++ b/t/lite_app.t
@@ -34,7 +34,7 @@ get '/unknown_helper' => 'unknown_helper';
 
 get '/on-disk' => 'foo';
 
-get '/foo/:message' => 'index';
+get '/foo/:message' => 'message';
 
 get '/inline' => sub { shift->render(inline => '[% 1 + 1 %]', handler => 'tt') };
 
@@ -75,7 +75,7 @@ $t->get_ok('/inline')->status_is(200)->content_is('2');
 
 __DATA__
 
-@@ index.html.tt
+@@ message.html.tt
 [% message %]
 
 @@ error.html.tt


### PR DESCRIPTION
Inline template calling changed.
Renamed template 'index' -> 'foo' because on-disk file templates/index.html.tt is loaded before templates in **DATA** section.
