### PR TITLE
[GH#12] Drop MojoX::* namespace

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,10 @@ Revision history for MojoX-Renderer-TT
 
 {{$NEXT}}
 
+1.14    August 1, 2011
+        - Drop use of MojoX namespace for Mojolicious::Plugin::TtRenderer::
+          (GH#12, Cosimo Streppone)
+
 1.13    June 7, 2011
         - Compatibility with Mojolicious 1.3+
 

--- a/lib/Mojolicious/Plugin/TtRenderer.pm
+++ b/lib/Mojolicious/Plugin/TtRenderer.pm
@@ -7,14 +7,14 @@ our $VERSION = '0.01';
 
 use base 'Mojolicious::Plugin';
 
-use MojoX::Renderer::TT;
+use Mojolicious::Plugin::TtRenderer::Engine;
 
 sub register {
     my ($self, $app, $args) = @_;
 
     $args ||= {};
 
-    my $tt = MojoX::Renderer::TT->build(%$args, app => $app);
+    my $tt = Mojolicious::Plugin::TtRenderer::Engine->build(%$args, app => $app);
 
     # Add "tt" handler
     $app->renderer->add_handler(tt => $tt);
@@ -54,6 +54,6 @@ Register renderer in L<Mojolicious> application.
 
 =head1 SEE ALSO
 
-L<MojoX::Renderer::TT>, L<Mojolicious>, L<Mojolicious::Guides>, L<http://mojolicious.org>.
+L<Mojolicious::Plugin::TtRenderer::Engine>, L<Mojolicious>, L<Mojolicious::Guides>, L<http://mojolicious.org>.
 
 =cut

--- a/lib/Mojolicious/Plugin/TtRenderer/Engine.pm
+++ b/lib/Mojolicious/Plugin/TtRenderer/Engine.pm
@@ -1,10 +1,11 @@
-package MojoX::Renderer::TT;
+package Mojolicious::Plugin::TtRenderer::Engine;
 
 use warnings;
 use strict;
 
 use base 'Mojo::Base';
 
+use Carp ();
 use File::Spec ();
 use Mojo::ByteStream 'b';
 use Template ();
@@ -43,7 +44,7 @@ sub _init {
     );
 
     $config{LOAD_TEMPLATES} =
-      [MojoX::Renderer::TT::Provider->new(%config, renderer => $app->renderer)]
+      [Mojolicious::Plugin::TtRenderer::Provider->new(%config, renderer => $app->renderer)]
       unless $config{LOAD_TEMPLATES};
 
     $self->tt(Template->new(\%config))
@@ -64,7 +65,7 @@ sub _render {
     return unless $t;
 
 
-    my $helper = MojoX::Renderer::TT::Helper->new(ctx => $c);
+    my $helper = Mojolicious::Plugin::TtRenderer::Helper->new(ctx => $c);
 
     # Purge previous result
     $$output = '';
@@ -90,10 +91,10 @@ sub _render {
     return 1;
 }
 
-1;    # End of MojoX::Renderer::TT
+1;    # End of Mojolicious::Plugin::TtRenderer::Engine
 
 package
-  MojoX::Renderer::TT::Helper;
+  Mojolicious::Plugin::TtRenderer::Helper;
 
 use strict;
 use warnings;
@@ -123,7 +124,7 @@ sub AUTOLOAD {
 1;
 
 package
-  MojoX::Renderer::TT::Provider;
+  Mojolicious::Plugin::TtRenderer::Provider;
 
 use strict;
 use warnings;
@@ -177,7 +178,7 @@ __END__
 
 =head1 NAME
 
-MojoX::Renderer::TT - Template Toolkit renderer for Mojo
+Mojolicious::Plugin::TtRenderer::Engine - Template Toolkit renderer for Mojo
 
 =head1 SYNOPSIS
 
@@ -190,9 +191,9 @@ Add the handler:
         $self->plugin(tt_renderer => {template_options => {FILTERS => [ ... ]}});
 
         # Or manually
-        use MojoX::Renderer::TT;
+        use Mojolicious::Plugin::TtRenderer::Engine;
 
-        my $tt = MojoX::Renderer::TT->build(
+        my $tt = Mojolicious::Plugin::TtRenderer::Engine->build(
             mojo => $self,
             template_options => {
                 PROCESS  => 'tpl/wrapper',
@@ -240,7 +241,7 @@ Supported parameters are
 
 =item mojo
 C<build> currently uses a C<mojo> parameter pointing to the base class (Mojo).
-object. When used the INCLUDE_PATH will be set to 
+object. When used the INCLUDE_PATH will be set to
 
 =item template_options
 
@@ -271,7 +272,7 @@ make changes.
 
 You can find documentation for this module with the perldoc command.
 
-    perldoc MojoX::Renderer::TT
+    perldoc Mojolicious::Plugin::TtRenderer::Engine
 
 You can also look for information at:
 

--- a/t/00-load.t
+++ b/t/00-load.t
@@ -3,7 +3,7 @@
 use Test::More tests => 1;
 
 BEGIN {
-	use_ok( 'MojoX::Renderer::TT' );
+	use_ok( 'Mojolicious::Plugin::TtRenderer::Engine' );
 }
 
-diag( "Testing MojoX::Renderer::TT $MojoX::Renderer::TT::VERSION, Perl $], $^X" );
+diag( "Testing Mojolicious::Plugin::TtRenderer::Engine $Mojolicious::Plugin::TtRenderer::Engine::VERSION, Perl $], $^X" );

--- a/t/lite_app.t
+++ b/t/lite_app.t
@@ -16,7 +16,7 @@ use Test::Mojo;
 # Silence
 app->log->level('fatal');
 
-use_ok('MojoX::Renderer::TT');
+use_ok('Mojolicious::Plugin::TtRenderer::Engine');
 
 plugin 'tt_renderer' => {template_options => {PRE_CHOMP => 1, POST_CHOMP => 1, TRIM => 1}};
 


### PR DESCRIPTION
Hi Ask,

I read about issue #12. Since I'm going to put Mojolicious based apps in production Soon(tm), and I need packaging deb stuff, I'd hoped to have something stable out for a while. I had a chat with Sebastian on IRC, and he explained about the namespace issue. I decided to work on this patch. Any feedback from your part?

---

Renamed MojoX:: namespace to Mojolicious::Plugin::TtRenderer::Engine,
so there's ::Engine, ::Helper and ::Provider.
## MojoX:: is deprecated and not to be used, according to @sri.
