### PR TITLE
Avoiding infinite loop when getting an exception during render_exception

### DIFF
--- a/lib/Mojolicious/Plugin/TtRenderer/Engine.pm
+++ b/lib/Mojolicious/Plugin/TtRenderer/Engine.pm
@@ -86,11 +86,12 @@ sub _render {
     my $ok = $self->tt->process(defined $inline ? \$inline : $t, @params);
 
     # Error
+    my $rendering_exception = $t =~ /^exception./;    
     unless ($ok) {
-
         my $e = Mojo::Exception->new($self->tt->error.'');
         $$output = '';
         $c->app->log->error(qq/Template error in "$t": $e/);
+        return if $rendering_exception;
         $c->render_exception($e);
         $self->tt->error('');
         return 0;


### PR DESCRIPTION
After processing the template fails, I added a check to see if the template was an exception template. In that case returning before calling render_exception. The render_exception causes a infinite loop. There is probably better way to figure out if we are in the middle of rendering an exception.
