### PR TITLE
Bug with setting cache_dir to relative path

### DIFF
--- a/lib/Mojolicious/Plugin/TtRenderer/Engine.pm
+++ b/lib/Mojolicious/Plugin/TtRenderer/Engine.pm
@@ -34,7 +34,7 @@ sub _init {
     if($dir=$args{cache_dir}) {
 
       if($app && substr($dir,0,1) ne '/') {
-        $dir=$app->home->rel_dir('tmp/ctpl');
+        $dir=$app->home->rel_dir($dir);
       }
     }
 


### PR DESCRIPTION
Regardless of what you specify for a relative (anything that doesn't begin with slash) you get [app home]/tmp/cpl.  Looks like there is an errant hardcode in there.
