### PR TITLE
make modified content applied on page refresh

### DIFF
--- a/lib/Mojolicious/Plugin/TtRenderer/Engine.pm
+++ b/lib/Mojolicious/Plugin/TtRenderer/Engine.pm
@@ -177,7 +177,7 @@ sub options       { @_ > 1 ? $_[0]->{options}       = $_[1] : $_[0]->{options} }
 
 sub _template_modified {
     my($self, $template) = @_;
-    return 1 if $self->SUPER::_template_modified($template);
+    return $self->SUPER::_template_modified($template) if -r $template;
     return $template =~ /^templates(?:\/|\\)/;
 }
 
@@ -186,11 +186,11 @@ sub _template_content {
     my ($path) = @_;
 
     my $options = delete $self->{options};
-    
+
     # Convert backslashes to forward slashes to make inline templates work on Windows
     $path =~ s/\\/\//g;
     my ($t) = ($path =~ m{templates\/(.*)$});
-    
+
     if (-r $path) {
         return $self->SUPER::_template_content(@_);
     }
@@ -232,13 +232,13 @@ Add the handler:
 
  sub startup {
      ...
- 
+
      # Via mojolicious plugin
      $self->plugin(tt_renderer => {template_options => {FILTERS => [ ... ]}});
- 
+
      # Or manually
      use Mojolicious::Plugin::TtRenderer::Engine;
- 
+
      my $tt = Mojolicious::Plugin::TtRenderer::Engine->build(
          mojo => $self,
          template_options => {
@@ -306,9 +306,9 @@ templates. Will default to a temp-dir if not set.
 
 =head1 SEE ALSO
 
-L<Mojolicious::Plugin::TtRenderer::Engine>, 
-L<Mojolicious>, 
-L<Mojolicious::Guides>, 
+L<Mojolicious::Plugin::TtRenderer::Engine>,
+L<Mojolicious>,
+L<Mojolicious::Guides>,
 L<http://mojolicious.org>.
 
 =head1 AUTHOR


### PR DESCRIPTION
I just do not understand why return 1 instead of the mtime if that's a real file changes.

I'm using this module and I had to restart my app when I change any tt files. that's too BAD.

this patch should work as expected (tested).

you start the daemon, you change any tt files, you refresh the page, the changes applied.

let me know if any issue. Thanks.
