### PR TITLE
fix for defaults layout

### DIFF
--- a/lib/Mojolicious/Plugin/TtRenderer/Engine.pm
+++ b/lib/Mojolicious/Plugin/TtRenderer/Engine.pm
@@ -81,11 +81,15 @@ sub _render {
     $t = 'inline' if defined $inline;
     return unless $t;
 
-
     my $helper = Mojolicious::Plugin::TtRenderer::Helper->new(ctx => $c);
 
     # Purge previous result
     $$output = '';
+
+    # fixes for t/lite_app_with_default_layouts.t
+    unless ($c->stash->{layout}) {
+        $c->stash->{content} ||= $c->stash->{'mojo.content'}->{content};
+    }
 
     my @params = ({%{$c->stash}, c => $c, h => $helper}, $output, {binmode => ':utf8'});
     my $provider = $self->tt->{SERVICE}->{CONTEXT}->{LOAD_TEMPLATES}->[0];

--- a/t/lite_app_with_default_layouts.t
+++ b/t/lite_app_with_default_layouts.t
@@ -1,0 +1,37 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+
+BEGIN { $ENV{MOJO_MODE}='testing'; };
+
+use utf8;
+
+use Test::More tests => 3;
+
+use Mojolicious::Lite;
+use Mojo::ByteStream 'b';
+use Test::Mojo;
+use File::Temp qw( tempdir );
+
+# Silence
+app->log->level('fatal');
+
+use_ok('Mojolicious::Plugin::TtRenderer::Engine');
+
+plugin 'tt_renderer' => {template_options => {PRE_CHOMP => 1, POST_CHOMP => 1, TRIM => 1, COMPILE_DIR => tempdir( CLEANUP => 1 ) }};
+app->defaults(layout => 'wrapper');
+
+get '/test' => 'test';
+
+my $t = Test::Mojo->new;
+
+$t->get_ok('/test')->content_is("WS-hello-EW");
+
+__DATA__
+
+@@ test.html.tt
+hello
+
+@@ layouts/wrapper.html.tt
+WS-[%- content -%]-EW


### PR DESCRIPTION
Hi. I commit a simple tests t/lite_app_with_default_layouts.t as in https://github.com/fayland/mojox-renderer-tt/commit/95d9ee5c356fa3f398b2deed9611ba47b69a890b

`app->defaults(layout => 'wrapper');`

then every template is just returning the content in the wrapper.html.tt
'WS--EW'

the [% content %] got lost.

I provide a patch too but not sure if that's a correct fix or not. please take a look and let me know if you can fix it in other way, or tell me I'm using the plugin in a wrong way.
