### PR TITLE
Fix template names in text and variable name in heading

### DIFF
--- a/example/myapp/templates/example/welcome.html.tt
+++ b/example/myapp/templates/example/welcome.html.tt
@@ -2,9 +2,9 @@
   WRAPPER 'layouts/default.html.tt'
   title = 'Welcome'
 %]
-<h2>[% $message %]</h2>
-This page was generated from the template "templates/example/welcome.html.ep"
-and the layout "templates/layouts/default.html.ep",
+<h2>[% message %]</h2>
+This page was generated from the template "templates/example/welcome.html.tt"
+and the layout "templates/layouts/default.html.tt",
 <a href="[% url_for %]">click here</a> to reload the page or
 <a href="/index.html">here</a> to move forward to a static page.
 [% END %]


### PR DESCRIPTION
I believe this will make the example app functional.
In the old version the <h2/> heading didn't get shown.
